### PR TITLE
Added Hungarian translation

### DIFF
--- a/Custom/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
+++ b/Custom/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
@@ -12,6 +12,8 @@ package Kernel::Output::HTML::Dashboard::MyLastChangedTickets;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our $ObjectManagerDisabled = 1;
 
 sub new {
@@ -42,7 +44,7 @@ sub Preferences {
 
     my @Params = (
         {
-            Desc  => 'Shown Tickets',
+            Desc  => Translatable('Shown Tickets'),
             Name  => $Self->{PrefKeyShown},
             Block => 'Option',
             Data  => {

--- a/Custom/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
+++ b/Custom/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
@@ -12,7 +12,7 @@
     <span style="height: 25px">
         <a href="javascript:void(0);"
            onclick="PS.MyLastChangedTickets.RefreshMylastchangetickets()"
-           id="mylastchangedtickets-refresh">[% Translate("refresh") | html %]</a>
+           id="mylastchangedtickets-refresh">[% Translate("Refresh") | html %]</a>
         <span id="mylastchangedtickets-spinner"></span>
     </span>
 [% RenderBlockEnd("Refresh") %]
@@ -29,7 +29,7 @@
 [% RenderBlockStart("NoTickets") %]
         <tr>
             <td>
-                [% Translate("none") | html %]
+                [% Translate("No tickets found.") | html %]
             </td>
         </tr>
 [% RenderBlockEnd("NoTickets") %]

--- a/DashboardMyLastChangedTickets.sopm
+++ b/DashboardMyLastChangedTickets.sopm
@@ -2,18 +2,21 @@
 <otrs_package version="1.0">
     <!-- GENERATED WITH OTRS::OPM::Maker::Command::sopm (1.33) -->
     <Name>DashboardMyLastChangedTickets</Name>
-    <Version>5.0.1</Version>
+    <Version>5.0.2</Version>
     <Framework>5.0.x</Framework>
+    <PackageRequired Version="5.0.2">CallDashboardElement</PackageRequired>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de</URL>
-    <Description Lang="de">Dashboard mit einer Liste von Tickets an denen ich gearbeitet habe</Description>
-    <Description Lang="en">Dashboard widgets to get a list of tickets I worked on</Description>
+    <Description Lang="de">Dashboard mit einer Liste von Tickets an denen ich gearbeitet habe.</Description>
+    <Description Lang="en">Dashboard widget to get a list of tickets I worked on.</Description>
+    <Description Lang="hu">Vezérlőpult felületi elem azon jegyek listájához, amelyekkel dolgozik.</Description>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
     <Filelist>
         <File Permission="644" Location="Custom/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm" />
         <File Permission="644" Location="Custom/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt" />
         <File Permission="644" Location="Kernel/Config/Files/DasboardMyLastChangedTickets.xml" />
         <File Permission="644" Location="Kernel/Language/de_DashboardMyLastChangedTickets.pm" />
+        <File Permission="644" Location="Kernel/Language/hu_DashboardMyLastChangedTickets.pm" />
         <File Permission="644" Location="doc/DashboardMyLastChangedTickets.json" />
         <File Permission="644" Location="var/httpd/htdocs/js/PS.MyLastChangedTickets.js" />
     </Filelist>

--- a/Kernel/Config/Files/DasboardMyLastChangedTickets.xml
+++ b/Kernel/Config/Files/DasboardMyLastChangedTickets.xml
@@ -32,8 +32,8 @@
         <SubGroup>Frontend::Agent::Dashboard::MyLastChangedTickets</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">No</Item>
-                <Item Key="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Language/de_DashboardMyLastChangedTickets.pm
+++ b/Kernel/Language/de_DashboardMyLastChangedTickets.pm
@@ -1,6 +1,6 @@
 # --
-# Kernel/Language/de_DashboardMyLastChangedTickets.pm - the german translation of DashboardMyLastChangedTickets
-# Copyright (C) 2015 Perl-Services, http://www.perl-services.de
+# Kernel/Language/de_DashboardMyLastChangedTickets.pm - the German translation of DashboardMyLastChangedTickets
+# Copyright (C) 2015 - 2016 Perl-Services, http://www.perl-services.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -17,13 +17,22 @@ use utf8;
 sub Data {
     my $Self = shift;
 
-    my $Lang = $Self->{Translation};
+    my $Lang = $Self->{Translation} || {};
 
-    return if ref $Lang ne 'HASH';
+    # Custom/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
+    $Lang->{'Shown Tickets'} = 'Gezeigte Tickets';
 
+    # Custom/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
+    $Lang->{'Refresh'} = 'Aktualisieren';
+    $Lang->{'No tickets found.'} = '';
+
+    # Kernel/Config/Files/DasboardMyLastChangedTickets.xml
+    $Lang->{'MyLastChangedTickets dashboard widget.'} = '';
     $Lang->{'My last changed tickets'} = 'Meine zuletzt bearbeiteten Tickets';
-
-    return 1;
+    $Lang->{'Defines the number of tickets shown in the widget.'} = '';
+    $Lang->{'Shows a link to refresh the widget (needs free add-on \'CallDashboardElement\').'} = '';
+    $Lang->{'List of JS files to always be loaded for the agent interface.'} =
+        'Liste der JavaScript-Dateien, die immer im Agenten-Interface geladen werden sollen.';
 }
 
 1;

--- a/Kernel/Language/hu_DashboardMyLastChangedTickets.pm
+++ b/Kernel/Language/hu_DashboardMyLastChangedTickets.pm
@@ -1,0 +1,41 @@
+# --
+# Kernel/Language/hu_DashboardMyLastChangedTickets.pm - the Hungarian translation of DashboardMyLastChangedTickets
+# Copyright (C) 2015 - 2016 Perl-Services, http://www.perl-services.de
+# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_DashboardMyLastChangedTickets;
+
+use strict;
+use warnings;
+
+use utf8;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation} || {};
+
+    # Custom/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
+    $Lang->{'Shown Tickets'} = 'Megjelenített jegyek';
+
+    # Custom/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
+    $Lang->{'Refresh'} = 'Frissítés';
+    $Lang->{'No tickets found.'} = 'Nem találhatók jegyek.';
+
+    # Kernel/Config/Files/DasboardMyLastChangedTickets.xml
+    $Lang->{'MyLastChangedTickets dashboard widget.'} = 'A legutóbb módosított saját jegyek felületi elem.';
+    $Lang->{'My last changed tickets'} = 'Legutóbb módosított saját jegyek';
+    $Lang->{'Defines the number of tickets shown in the widget.'} =
+        'Meghatározza a felületi elemen megjelenített jegyek számát.';
+    $Lang->{'Shows a link to refresh the widget (needs free add-on \'CallDashboardElement\').'} =
+        'Egy hivatkozást jelenít meg a felületi elem frissítéséhez (az ingyenes „CallDashboardElement” kiegészítő szükséges hozzá).';
+    $Lang->{'List of JS files to always be loaded for the agent interface.'} =
+        'JS fájlok listája, amelyek mindig betöltődnek az ügyintézői felületnél.';
+}
+
+1;

--- a/doc/DashboardMyLastChangedTickets.json
+++ b/doc/DashboardMyLastChangedTickets.json
@@ -1,16 +1,17 @@
 {
     "name": "DashboardMyLastChangedTickets",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "framework": [
         "5.0.x"
     ],
     "vendor": {
-        "name":  "Perl-Services.de",
+        "name": "Perl-Services.de",
         "url": "http://www.perl-services.de"
     },
     "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007",
     "description" : {
-        "en": "Dashboard widgets to get a list of tickets I worked on",
-        "de": "Dashboard mit einer Liste von Tickets an denen ich gearbeitet habe"
+        "en": "Dashboard widget to get a list of tickets I worked on.",
+        "de": "Dashboard mit einer Liste von Tickets an denen ich gearbeitet habe.",
+        "hu": "Vezérlőpult felületi elem azon jegyek listájához, amelyekkel dolgozik."
     }
 }


### PR DESCRIPTION
Hi @reneeb 
Here is the Hungarian translation for this module. The German translation needs to be finished.
I also added `<PackageRequired Version="5.0.2">CallDashboardElement</PackageRequired>` to .sopm, since if an admin set the _Refresh_ link without this package, the agent will get an error when clicking the link. With this requirement the admin won't forget to install the dependency.
If you release the new version of this module (version number is bumped), please check https://github.com/reneeb/otrs-CallDashboardElement/pull/1 and also release CallDashboardElement, as now this packages depends on it.

Edit: `PackageRequired` needs to be added to `doc/DashboardMyLastChangedTickets.json`